### PR TITLE
Support for < SF2.7 discontinued

### DIFF
--- a/Form/Extension/GeoCodeExtension.php
+++ b/Form/Extension/GeoCodeExtension.php
@@ -5,7 +5,7 @@ namespace PUGX\GeoFormBundle\Form\Extension;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class GeoCodeExtension extends AbstractTypeExtension
 {
@@ -30,7 +30,7 @@ class GeoCodeExtension extends AbstractTypeExtension
         $builder->addEventSubscriber($this->listener);
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'geo_code' => false,

--- a/README.markdown
+++ b/README.markdown
@@ -7,7 +7,7 @@ PUGXGeoFormBundle
 
 A Symfony 2 bundle to handle geolocalization inside Forms.
 
-This branch supports Symfony >= 2.3
+This branch supports Symfony >= 2.7
 
 Documentation
 -------------

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -89,7 +89,7 @@ class SearchFormType extends AbstractType
         $builder->add('latitude', 'hidden', array('required' => false));
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'geo_code' => true,
@@ -130,7 +130,7 @@ class SearchFormType extends AbstractType
         $builder->add('latitude', 'hidden', array('required' => false));
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'geo_code' => true,
@@ -182,7 +182,7 @@ class SearchFormType extends AbstractType
         ));
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'geo_code' => true,

--- a/Tests/Form/Extension/GeoCodeExtensionTest.php
+++ b/Tests/Form/Extension/GeoCodeExtensionTest.php
@@ -29,7 +29,7 @@ class GeoCodeExtensionTest extends \PHPUnit_Framework_TestCase
                 'geo_code_field' => false,
             ));
 
-        $this->extension->setDefaultOptions($this->resolver);
+        $this->extension->configureOptions($this->resolver);
     }
 
     public function testBuildFormWithGeoCode()

--- a/composer.json
+++ b/composer.json
@@ -22,15 +22,15 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "~2.3",
-        "symfony/form": "~2.3",
-        "symfony/security-bundle": "~2.3",
+        "symfony/framework-bundle": "~2.7",
+        "symfony/form": "~2.7",
+        "symfony/security-bundle": "~2.7",
         "willdurand/geocoder": "@stable",
         "kriswallsmith/buzz": "@stable"
     },
     "require-dev": {
-        "symfony/yaml": "~2.3",
-        "symfony/validator": "~2.3"
+        "symfony/yaml": "~2.7",
+        "symfony/validator": "~2.7"
     },
     "suggest": {
     },


### PR DESCRIPTION
Rename old methods `AbstractType::setDefaultOptions(OptionsResolverInterface $resolver)` and `AbstractTypeExtension::setDefaultOptions(OptionsResolverInterface $resolver)` for SF3. Use `AbstractType::configureOptions(OptionsResolver $resolver)` and `AbstractTypeExtension::configureOptions(OptionsResolver $resolver)` instead :smile:

I.e: https://github.com/symfony/symfony/blob/master/UPGRADE-3.0.md
