### PR TITLE
Fix deprecated AbstracType::setDefaultOptions usage

### DIFF
--- a/Form/Extension/GeoCodeExtension.php
+++ b/Form/Extension/GeoCodeExtension.php
@@ -5,6 +5,7 @@ namespace PUGX\GeoFormBundle\Form\Extension;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class GeoCodeExtension extends AbstractTypeExtension
@@ -30,7 +31,20 @@ class GeoCodeExtension extends AbstractTypeExtension
         $builder->addEventSubscriber($this->listener);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * Symfony <2.7 BC. To be removed when bumping requirements to SF 2.7+
+     */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'geo_code' => false,

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -89,7 +89,7 @@ class SearchFormType extends AbstractType
         $builder->add('latitude', 'hidden', array('required' => false));
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'geo_code' => true,
@@ -130,7 +130,7 @@ class SearchFormType extends AbstractType
         $builder->add('latitude', 'hidden', array('required' => false));
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'geo_code' => true,
@@ -182,7 +182,7 @@ class SearchFormType extends AbstractType
         ));
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'geo_code' => true,

--- a/Tests/Form/Extension/GeoCodeExtensionTest.php
+++ b/Tests/Form/Extension/GeoCodeExtensionTest.php
@@ -8,6 +8,10 @@ class GeoCodeExtensionTest extends \PHPUnit_Framework_TestCase
 {
     protected $resolver;
     protected $listener;
+
+    /**
+     * @var GeoCodeExtension
+     */
     protected $extension;
     protected $formBuilder;
 
@@ -19,6 +23,9 @@ class GeoCodeExtensionTest extends \PHPUnit_Framework_TestCase
         $this->extension = new GeoCodeExtension($this->listener);
     }
 
+    /**
+     * @group legacy
+     */
     public function testSetDefaultOptions()
     {
         $this->resolver
@@ -30,6 +37,19 @@ class GeoCodeExtensionTest extends \PHPUnit_Framework_TestCase
             ));
 
         $this->extension->setDefaultOptions($this->resolver);
+    }
+
+    public function testConfigureOptions()
+    {
+        $this->resolver
+            ->expects($this->once())
+            ->method('setDefaults')
+            ->with(array(
+                'geo_code' => false,
+                'geo_code_field' => false,
+            ));
+
+        $this->extension->configureOptions($this->resolver);
     }
 
     public function testBuildFormWithGeoCode()

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
     },
     "require-dev": {
         "symfony/yaml": "~2.3",
-        "symfony/validator": "~2.3"
+        "symfony/validator": "~2.3",
+        "symfony/phpunit-bridge": "^2.7.4"
     },
     "suggest": {
     },


### PR DESCRIPTION
Alternative to #5.

SF 2.3+ BC support.