### PR TITLE
Change Composer constraint for Geocoder (Hotfix)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/framework-bundle": "~2.3",
         "symfony/form": "~2.3",
         "symfony/security-bundle": "~2.3",
-        "willdurand/geocoder": "~3.0",
+        "willdurand/geocoder": "~2.8",
         "kriswallsmith/buzz": "~0.15"
     },
     "require-dev": {


### PR DESCRIPTION
The bundle doesn't work with Geocode `3.x.x`.
